### PR TITLE
Use the correct type to create the logger

### DIFF
--- a/OCPP.Core.Management/Controllers/ApiController.Reset.cs
+++ b/OCPP.Core.Management/Controllers/ApiController.Reset.cs
@@ -42,7 +42,7 @@ namespace OCPP.Core.Management.Controllers
             IConfiguration config) : base(userManager, loggerFactory, config)
         {
             _localizer = localizer;
-            Logger = loggerFactory.CreateLogger<HomeController>();
+            Logger = loggerFactory.CreateLogger<ApiController>();
         }
 
         [Authorize]


### PR DESCRIPTION
Looks like a simple typo. It affect the logging, reporting the wrong controller.