### PR TITLE
Do not wait for WriteMessageLog

### DIFF
--- a/OCPP.Core.Server/ControllerOCPP16.Authorize.cs
+++ b/OCPP.Core.Server/ControllerOCPP16.Authorize.cs
@@ -88,7 +88,7 @@ namespace OCPP.Core.Server
                 errorCode = ErrorCodes.FormationViolation;
             }
 
-            WriteMessageLog(ChargePointStatus?.Id, null,msgIn.Action, $"'{idTag}'=>{authorizeResponse.IdTagInfo?.Status}", errorCode);
+            _ = WriteMessageLog(ChargePointStatus?.Id, null,msgIn.Action, $"'{idTag}'=>{authorizeResponse.IdTagInfo?.Status}", errorCode);
             return errorCode;
         }
     }

--- a/OCPP.Core.Server/ControllerOCPP16.BootNotification.cs
+++ b/OCPP.Core.Server/ControllerOCPP16.BootNotification.cs
@@ -65,7 +65,7 @@ namespace OCPP.Core.Server
                 errorCode = ErrorCodes.FormationViolation;
             }
 
-            WriteMessageLog(ChargePointStatus.Id, null, msgIn.Action, null, errorCode);
+            _ = WriteMessageLog(ChargePointStatus.Id, null, msgIn.Action, null, errorCode);
             return errorCode;
         }
     }

--- a/OCPP.Core.Server/ControllerOCPP16.DataTransfer.cs
+++ b/OCPP.Core.Server/ControllerOCPP16.DataTransfer.cs
@@ -30,7 +30,7 @@ namespace OCPP.Core.Server
 {
     public partial class ControllerOCPP16
     {
-        public string HandleDataTransfer(OCPPMessage msgIn, OCPPMessage msgOut)
+        public async Task<string> HandleDataTransfer(OCPPMessage msgIn, OCPPMessage msgOut)
         {
             string errorCode = null;
             DataTransferResponse dataTransferResponse = new DataTransferResponse();
@@ -46,7 +46,7 @@ namespace OCPP.Core.Server
                 if (ChargePointStatus != null)
                 {
                     // Known charge station
-                    msgWritten = WriteMessageLog(ChargePointStatus.Id, null, msgIn.Action, string.Format("VendorId={0} / MessageId={1} / Data={2}", dataTransferRequest.VendorId, dataTransferRequest.MessageId, dataTransferRequest.Data), errorCode);
+                    msgWritten = await WriteMessageLog(ChargePointStatus.Id, null, msgIn.Action, string.Format("VendorId={0} / MessageId={1} / Data={2}", dataTransferRequest.VendorId, dataTransferRequest.MessageId, dataTransferRequest.Data), errorCode);
                     dataTransferResponse.Status = DataTransferResponseStatus.Accepted;
                 }
                 else
@@ -66,7 +66,7 @@ namespace OCPP.Core.Server
 
             if (!msgWritten)
             {
-                WriteMessageLog(ChargePointStatus.Id, null, msgIn.Action, null, errorCode);
+                _ = WriteMessageLog(ChargePointStatus.Id, null, msgIn.Action, null, errorCode);
             }
             return errorCode;
         }

--- a/OCPP.Core.Server/ControllerOCPP16.Heartbeat.cs
+++ b/OCPP.Core.Server/ControllerOCPP16.Heartbeat.cs
@@ -41,7 +41,7 @@ namespace OCPP.Core.Server
             msgOut.JsonPayload = JsonConvert.SerializeObject(heartbeatResponse);
             Logger.LogTrace("Heartbeat => Response serialized");
 
-            WriteMessageLog(ChargePointStatus?.Id, null, msgIn.Action, null, errorCode);
+            _ = WriteMessageLog(ChargePointStatus?.Id, null, msgIn.Action, null, errorCode);
             return errorCode;
         }
     }

--- a/OCPP.Core.Server/ControllerOCPP16.MeterValues.cs
+++ b/OCPP.Core.Server/ControllerOCPP16.MeterValues.cs
@@ -215,7 +215,7 @@ namespace OCPP.Core.Server
                 errorCode = ErrorCodes.InternalError;
             }
 
-            WriteMessageLog(ChargePointStatus.Id, connectorId, msgIn.Action, msgMeterValue, errorCode);
+            _ = WriteMessageLog(ChargePointStatus.Id, connectorId, msgIn.Action, msgMeterValue, errorCode);
             return errorCode;
         }
     }

--- a/OCPP.Core.Server/ControllerOCPP16.Reset.cs
+++ b/OCPP.Core.Server/ControllerOCPP16.Reset.cs
@@ -39,7 +39,7 @@ namespace OCPP.Core.Server
             {
                 ResetResponse resetResponse = DeserializeMessage<ResetResponse>(msgIn);
                 Logger.LogInformation("Reset => Answer status: {0}", resetResponse?.Status);
-                WriteMessageLog(ChargePointStatus?.Id, null, msgOut.Action, resetResponse?.Status.ToString(), msgIn.ErrorCode);
+                _ = WriteMessageLog(ChargePointStatus?.Id, null, msgOut.Action, resetResponse?.Status.ToString(), msgIn.ErrorCode);
 
                 if (msgOut.TaskCompletionSource != null)
                 {

--- a/OCPP.Core.Server/ControllerOCPP16.StatusNotification.cs
+++ b/OCPP.Core.Server/ControllerOCPP16.StatusNotification.cs
@@ -30,7 +30,7 @@ namespace OCPP.Core.Server
 {
     public partial class ControllerOCPP16
     {
-        public string HandleStatusNotification(OCPPMessage msgIn, OCPPMessage msgOut)
+        public async Task<string> HandleStatusNotificationAsync(OCPPMessage msgIn, OCPPMessage msgOut)
         {
             string errorCode = null;
             StatusNotificationResponse statusNotificationResponse = new StatusNotificationResponse();
@@ -47,7 +47,7 @@ namespace OCPP.Core.Server
                 connectorId = statusNotificationRequest.ConnectorId;
 
                 // Write raw status in DB
-                msgWritten = WriteMessageLog(ChargePointStatus.Id, connectorId, msgIn.Action, string.Format("Info={0} / Status={1} / ", statusNotificationRequest.Info, statusNotificationRequest.Status), statusNotificationRequest.ErrorCode.ToString());
+                msgWritten = await WriteMessageLog(ChargePointStatus.Id, connectorId, msgIn.Action, string.Format("Info={0} / Status={1} / ", statusNotificationRequest.Info, statusNotificationRequest.Status), statusNotificationRequest.ErrorCode.ToString());
 
                 ConnectorStatusEnum newStatus = ConnectorStatusEnum.Undefined;
 
@@ -116,7 +116,7 @@ namespace OCPP.Core.Server
 
             if (!msgWritten)
             {
-                WriteMessageLog(ChargePointStatus.Id, connectorId, msgIn.Action, null, errorCode);
+                _ = WriteMessageLog(ChargePointStatus.Id, connectorId, msgIn.Action, null, errorCode);
             }
             return errorCode;
         }

--- a/OCPP.Core.Server/ControllerOCPP16.StopTransaction.cs
+++ b/OCPP.Core.Server/ControllerOCPP16.StopTransaction.cs
@@ -142,7 +142,7 @@ namespace OCPP.Core.Server
                         else
                         {
                             Logger.LogError("StopTransaction => Unknown or not matching transaction: id={0} / chargepoint={1} / tag={2}", stopTransactionRequest.TransactionId, ChargePointStatus?.Id, idTag);
-                            WriteMessageLog(ChargePointStatus?.Id, transaction?.ConnectorId, msgIn.Action, string.Format("UnknownTransaction:ID={0}/Meter={1}", stopTransactionRequest.TransactionId, stopTransactionRequest.MeterStop), errorCode);
+                            _ = WriteMessageLog(ChargePointStatus?.Id, transaction?.ConnectorId, msgIn.Action, string.Format("UnknownTransaction:ID={0}/Meter={1}", stopTransactionRequest.TransactionId, stopTransactionRequest.MeterStop), errorCode);
                             errorCode = ErrorCodes.PropertyConstraintViolation;
                         }
                     }
@@ -162,7 +162,7 @@ namespace OCPP.Core.Server
                 errorCode = ErrorCodes.FormationViolation;
             }
 
-            WriteMessageLog(ChargePointStatus?.Id, null, msgIn.Action, stopTransactionResponse.IdTagInfo?.Status.ToString(), errorCode);
+            _ = WriteMessageLog(ChargePointStatus?.Id, null, msgIn.Action, stopTransactionResponse.IdTagInfo?.Status.ToString(), errorCode);
             return errorCode;
         }
     }

--- a/OCPP.Core.Server/ControllerOCPP16.UnlockConnector.cs
+++ b/OCPP.Core.Server/ControllerOCPP16.UnlockConnector.cs
@@ -39,7 +39,7 @@ namespace OCPP.Core.Server
             {
                 UnlockConnectorResponse unlockConnectorResponse = DeserializeMessage<UnlockConnectorResponse>(msgIn);
                 Logger.LogInformation("HandleUnlockConnector => Answer status: {0}", unlockConnectorResponse?.Status);
-                WriteMessageLog(ChargePointStatus?.Id, null, msgOut.Action, unlockConnectorResponse?.Status.ToString(), msgIn.ErrorCode);
+                _ = WriteMessageLog(ChargePointStatus?.Id, null, msgOut.Action, unlockConnectorResponse?.Status.ToString(), msgIn.ErrorCode);
 
                 if (msgOut.TaskCompletionSource != null)
                 {

--- a/OCPP.Core.Server/ControllerOCPP16.cs
+++ b/OCPP.Core.Server/ControllerOCPP16.cs
@@ -51,7 +51,7 @@ namespace OCPP.Core.Server
         /// <summary>
         /// Processes the charge point message and returns the answer message
         /// </summary>
-        public OCPPMessage ProcessRequest(OCPPMessage msgIn)
+        public async Task<OCPPMessage> ProcessRequest(OCPPMessage msgIn)
         {
             OCPPMessage msgOut = new OCPPMessage();
             msgOut.MessageType = "3";
@@ -74,7 +74,7 @@ namespace OCPP.Core.Server
                     break;
 
                 case "StartTransaction":
-                    errorCode = HandleStartTransaction(msgIn, msgOut);
+                    errorCode = await HandleStartTransaction(msgIn, msgOut);
                     break;
 
                 case "StopTransaction":
@@ -86,16 +86,16 @@ namespace OCPP.Core.Server
                     break;
 
                 case "StatusNotification":
-                    errorCode = HandleStatusNotification(msgIn, msgOut);
+                    errorCode = await HandleStatusNotificationAsync(msgIn, msgOut);
                     break;
 
                 case "DataTransfer":
-                    errorCode = HandleDataTransfer(msgIn, msgOut);
+                    errorCode = await HandleDataTransfer(msgIn, msgOut);
                     break;
 
                 default:
                     errorCode = ErrorCodes.NotSupported;
-                    WriteMessageLog(ChargePointStatus.Id, null, msgIn.Action, msgIn.JsonPayload, errorCode);
+                    _ = WriteMessageLog(ChargePointStatus.Id, null, msgIn.Action, msgIn.JsonPayload, errorCode);
                     break;
             }
 
@@ -128,7 +128,7 @@ namespace OCPP.Core.Server
                     break;
 
                 default:
-                    WriteMessageLog(ChargePointStatus.Id, null, msgIn.Action, msgIn.JsonPayload, "Unknown answer");
+                    _ = WriteMessageLog(ChargePointStatus.Id, null, msgIn.Action, msgIn.JsonPayload, "Unknown answer");
                     break;
             }
         }
@@ -136,7 +136,7 @@ namespace OCPP.Core.Server
         /// <summary>
         /// Helper function for writing a log entry in database
         /// </summary>
-        private bool WriteMessageLog(string chargePointId, int? connectorId, string message, string result, string errorCode)
+        private async Task<bool> WriteMessageLog(string chargePointId, int? connectorId, string message, string result, string errorCode)
         {
             try
             {
@@ -160,7 +160,7 @@ namespace OCPP.Core.Server
                         msgLog.ErrorCode = errorCode;
                         DbContext.MessageLogs.Add(msgLog);
                         Logger.LogTrace("MessageLog => Writing entry '{0}'", message);
-                        DbContext.SaveChanges();
+                        await DbContext.SaveChangesAsync();
                         return true;
                     }
                 }

--- a/OCPP.Core.Server/ControllerOCPP20.Authorize.cs
+++ b/OCPP.Core.Server/ControllerOCPP20.Authorize.cs
@@ -99,7 +99,7 @@ namespace OCPP.Core.Server
                 errorCode = ErrorCodes.FormationViolation;
             }
 
-            WriteMessageLog(ChargePointStatus?.Id, null, msgIn.Action, $"'{idTag}'=>{authorizeResponse.IdTokenInfo?.Status}", errorCode);
+            _ = WriteMessageLog(ChargePointStatus?.Id, null, msgIn.Action, $"'{idTag}'=>{authorizeResponse.IdTokenInfo?.Status}", errorCode);
             return errorCode;
         }
     }

--- a/OCPP.Core.Server/ControllerOCPP20.BootNotification.cs
+++ b/OCPP.Core.Server/ControllerOCPP20.BootNotification.cs
@@ -75,7 +75,7 @@ namespace OCPP.Core.Server
                 errorCode = ErrorCodes.FormationViolation;
             }
 
-            WriteMessageLog(ChargePointStatus.Id, null, msgIn.Action, bootReason, errorCode);
+            _ = WriteMessageLog(ChargePointStatus.Id, null, msgIn.Action, bootReason, errorCode);
             return errorCode;
         }
     }

--- a/OCPP.Core.Server/ControllerOCPP20.ClearedChargingLimit.cs
+++ b/OCPP.Core.Server/ControllerOCPP20.ClearedChargingLimit.cs
@@ -69,7 +69,7 @@ namespace OCPP.Core.Server
                 errorCode = ErrorCodes.InternalError;
             }
 
-            WriteMessageLog(ChargePointStatus.Id, connectorId, msgIn.Action, source, errorCode);
+            _ = WriteMessageLog(ChargePointStatus.Id, connectorId, msgIn.Action, source, errorCode);
             return errorCode;
         }
     }

--- a/OCPP.Core.Server/ControllerOCPP20.DataTransfer.cs
+++ b/OCPP.Core.Server/ControllerOCPP20.DataTransfer.cs
@@ -30,7 +30,7 @@ namespace OCPP.Core.Server
 {
     public partial class ControllerOCPP20
     {
-        public string HandleDataTransfer(OCPPMessage msgIn, OCPPMessage msgOut)
+        public async Task<string> HandleDataTransfer(OCPPMessage msgIn, OCPPMessage msgOut)
         {
             string errorCode = null;
             DataTransferResponse dataTransferResponse = new DataTransferResponse();
@@ -46,7 +46,7 @@ namespace OCPP.Core.Server
                 if (ChargePointStatus != null)
                 {
                     // Known charge station
-                    msgWritten = WriteMessageLog(ChargePointStatus.Id, null, msgIn.Action, string.Format("VendorId={0} / MessageId={1} / Data={2}", dataTransferRequest.VendorId, dataTransferRequest.MessageId, dataTransferRequest.Data), errorCode);
+                    msgWritten = await WriteMessageLog(ChargePointStatus.Id, null, msgIn.Action, string.Format("VendorId={0} / MessageId={1} / Data={2}", dataTransferRequest.VendorId, dataTransferRequest.MessageId, dataTransferRequest.Data), errorCode);
                     dataTransferResponse.Status = DataTransferStatusEnumType.Accepted;
                 }
                 else
@@ -66,7 +66,7 @@ namespace OCPP.Core.Server
 
             if (!msgWritten)
             {
-                WriteMessageLog(ChargePointStatus.Id, null, msgIn.Action, null, errorCode);
+                _ = WriteMessageLog(ChargePointStatus.Id, null, msgIn.Action, null, errorCode);
             }
             return errorCode;
         }

--- a/OCPP.Core.Server/ControllerOCPP20.FirmwareStatusNotification.cs
+++ b/OCPP.Core.Server/ControllerOCPP20.FirmwareStatusNotification.cs
@@ -68,7 +68,7 @@ namespace OCPP.Core.Server
                 errorCode = ErrorCodes.InternalError;
             }
 
-            WriteMessageLog(ChargePointStatus.Id, null, msgIn.Action, status, errorCode);
+            _ = WriteMessageLog(ChargePointStatus.Id, null, msgIn.Action, status, errorCode);
             return errorCode;
         }
     }

--- a/OCPP.Core.Server/ControllerOCPP20.Heartbeat.cs
+++ b/OCPP.Core.Server/ControllerOCPP20.Heartbeat.cs
@@ -44,7 +44,7 @@ namespace OCPP.Core.Server
             msgOut.JsonPayload = JsonConvert.SerializeObject(heartbeatResponse);
             Logger.LogTrace("Heartbeat => Response serialized");
 
-            WriteMessageLog(ChargePointStatus?.Id, null, msgIn.Action, null, errorCode);
+            _ = WriteMessageLog(ChargePointStatus?.Id, null, msgIn.Action, null, errorCode);
             return errorCode;
         }
     }

--- a/OCPP.Core.Server/ControllerOCPP20.LogStatusNotification.cs
+++ b/OCPP.Core.Server/ControllerOCPP20.LogStatusNotification.cs
@@ -68,7 +68,7 @@ namespace OCPP.Core.Server
                 errorCode = ErrorCodes.InternalError;
             }
 
-            WriteMessageLog(ChargePointStatus.Id, null, msgIn.Action, status, errorCode);
+            _ = WriteMessageLog(ChargePointStatus.Id, null, msgIn.Action, status, errorCode);
             return errorCode;
         }
     }

--- a/OCPP.Core.Server/ControllerOCPP20.MeterValues.cs
+++ b/OCPP.Core.Server/ControllerOCPP20.MeterValues.cs
@@ -110,7 +110,7 @@ namespace OCPP.Core.Server
                 errorCode = ErrorCodes.InternalError;
             }
 
-            WriteMessageLog(ChargePointStatus.Id, connectorId, msgIn.Action, msgMeterValue, errorCode);
+            _ = WriteMessageLog(ChargePointStatus.Id, connectorId, msgIn.Action, msgMeterValue, errorCode);
             return errorCode;
         }
     }

--- a/OCPP.Core.Server/ControllerOCPP20.NotifyChargingLimit.cs
+++ b/OCPP.Core.Server/ControllerOCPP20.NotifyChargingLimit.cs
@@ -95,7 +95,7 @@ namespace OCPP.Core.Server
                 errorCode = ErrorCodes.InternalError;
             }
 
-            WriteMessageLog(ChargePointStatus.Id, connectorId, msgIn.Action, source, errorCode);
+            _ = WriteMessageLog(ChargePointStatus.Id, connectorId, msgIn.Action, source, errorCode);
             return errorCode;
         }
     }

--- a/OCPP.Core.Server/ControllerOCPP20.NotifyEVChargingSchedule.cs
+++ b/OCPP.Core.Server/ControllerOCPP20.NotifyEVChargingSchedule.cs
@@ -94,7 +94,7 @@ namespace OCPP.Core.Server
                 errorCode = ErrorCodes.InternalError;
             }
 
-            WriteMessageLog(ChargePointStatus.Id, connectorId, msgIn.Action, periods.ToString(), errorCode);
+            _ = WriteMessageLog(ChargePointStatus.Id, connectorId, msgIn.Action, periods.ToString(), errorCode);
             return errorCode;
         }
     }

--- a/OCPP.Core.Server/ControllerOCPP20.Reset.cs
+++ b/OCPP.Core.Server/ControllerOCPP20.Reset.cs
@@ -39,7 +39,7 @@ namespace OCPP.Core.Server
             {
                 ResetResponse resetResponse = DeserializeMessage<ResetResponse>(msgIn);
                 Logger.LogInformation("Reset => Answer status: {0}", resetResponse?.Status);
-                WriteMessageLog(ChargePointStatus?.Id, null, msgOut.Action, resetResponse?.Status.ToString(), msgIn.ErrorCode);
+                _ = WriteMessageLog(ChargePointStatus?.Id, null, msgOut.Action, resetResponse?.Status.ToString(), msgIn.ErrorCode);
 
                 if (msgOut.TaskCompletionSource != null)
                 {

--- a/OCPP.Core.Server/ControllerOCPP20.StatusNotification.cs
+++ b/OCPP.Core.Server/ControllerOCPP20.StatusNotification.cs
@@ -30,7 +30,7 @@ namespace OCPP.Core.Server
 {
     public partial class ControllerOCPP20
     {
-        public string HandleStatusNotification(OCPPMessage msgIn, OCPPMessage msgOut)
+        public async Task<string> HandleStatusNotification(OCPPMessage msgIn, OCPPMessage msgOut)
         {
             string errorCode = null;
             StatusNotificationResponse statusNotificationResponse = new StatusNotificationResponse();
@@ -50,7 +50,7 @@ namespace OCPP.Core.Server
                 connectorId = statusNotificationRequest.ConnectorId;
 
                 // Write raw status in DB
-                msgWritten = WriteMessageLog(ChargePointStatus.Id, connectorId, msgIn.Action, string.Format("Status={0}", statusNotificationRequest.ConnectorStatus), string.Empty);
+                msgWritten = await WriteMessageLog(ChargePointStatus.Id, connectorId, msgIn.Action, string.Format("Status={0}", statusNotificationRequest.ConnectorStatus), string.Empty);
 
                 ConnectorStatusEnum newStatus = ConnectorStatusEnum.Undefined;
 
@@ -114,7 +114,7 @@ namespace OCPP.Core.Server
 
             if (!msgWritten)
             {
-                WriteMessageLog(ChargePointStatus.Id, connectorId, msgIn.Action, null, errorCode);
+                _ = WriteMessageLog(ChargePointStatus.Id, connectorId, msgIn.Action, null, errorCode);
             }
             return errorCode;
         }

--- a/OCPP.Core.Server/ControllerOCPP20.UnlockConnector.cs
+++ b/OCPP.Core.Server/ControllerOCPP20.UnlockConnector.cs
@@ -39,7 +39,7 @@ namespace OCPP.Core.Server
             {
                 UnlockConnectorResponse unlockConnectorResponse = DeserializeMessage<UnlockConnectorResponse>(msgIn);
                 Logger.LogInformation("HandleUnlockConnector => Answer status: {0}", unlockConnectorResponse?.Status);
-                WriteMessageLog(ChargePointStatus?.Id, null, msgOut.Action, unlockConnectorResponse?.Status.ToString(), msgIn.ErrorCode);
+                _ = WriteMessageLog(ChargePointStatus?.Id, null, msgOut.Action, unlockConnectorResponse?.Status.ToString(), msgIn.ErrorCode);
 
                 if (msgOut.TaskCompletionSource != null)
                 {

--- a/OCPP.Core.Server/ControllerOCPP20.cs
+++ b/OCPP.Core.Server/ControllerOCPP20.cs
@@ -51,7 +51,7 @@ namespace OCPP.Core.Server
         /// <summary>
         /// Processes the charge point message and returns the answer message
         /// </summary>
-        public OCPPMessage ProcessRequest(OCPPMessage msgIn)
+        public async Task<OCPPMessage> ProcessRequest(OCPPMessage msgIn)
         {
             OCPPMessage msgOut = new OCPPMessage();
             msgOut.MessageType = "3";
@@ -76,7 +76,7 @@ namespace OCPP.Core.Server
                         break;
 
                     case "TransactionEvent":
-                        errorCode = HandleTransactionEvent(msgIn, msgOut);
+                        errorCode = await HandleTransactionEvent(msgIn, msgOut);
                         break;
 
                     case "MeterValues":
@@ -84,11 +84,11 @@ namespace OCPP.Core.Server
                         break;
 
                     case "StatusNotification":
-                        errorCode = HandleStatusNotification(msgIn, msgOut);
+                        errorCode = await HandleStatusNotification(msgIn, msgOut);
                         break;
 
                     case "DataTransfer":
-                        errorCode = HandleDataTransfer(msgIn, msgOut);
+                        errorCode = await HandleDataTransfer(msgIn, msgOut);
                         break;
 
                     case "LogStatusNotification":
@@ -113,7 +113,7 @@ namespace OCPP.Core.Server
 
                     default:
                         errorCode = ErrorCodes.NotSupported;
-                        WriteMessageLog(ChargePointStatus.Id, null, msgIn.Action, msgIn.JsonPayload, errorCode);
+                        _ = WriteMessageLog(ChargePointStatus.Id, null, msgIn.Action, msgIn.JsonPayload, errorCode);
                         break;
                 }
             }
@@ -151,7 +151,7 @@ namespace OCPP.Core.Server
                     break;
 
                 default:
-                    WriteMessageLog(ChargePointStatus.Id, null, msgIn.Action, msgIn.JsonPayload, "Unknown answer");
+                    _ = WriteMessageLog(ChargePointStatus.Id, null, msgIn.Action, msgIn.JsonPayload, "Unknown answer");
                     break;
             }
         }
@@ -159,7 +159,7 @@ namespace OCPP.Core.Server
         /// <summary>
         /// Helper function for writing a log entry in database
         /// </summary>
-        private bool WriteMessageLog(string chargePointId, int? connectorId, string message, string result, string errorCode)
+        private async Task<bool> WriteMessageLog(string chargePointId, int? connectorId, string message, string result, string errorCode)
         {
             try
             {
@@ -183,7 +183,7 @@ namespace OCPP.Core.Server
                         msgLog.ErrorCode = errorCode;
                         DbContext.MessageLogs.Add(msgLog);
                         Logger.LogTrace("MessageLog => Writing entry '{0}'", message);
-                        DbContext.SaveChanges();
+                        await DbContext.SaveChangesAsync();
                         return true;
                     }
                 }

--- a/OCPP.Core.Server/OCPPMiddleware.OCPP16.cs
+++ b/OCPP.Core.Server/OCPPMiddleware.OCPP16.cs
@@ -79,7 +79,7 @@ namespace OCPP.Core.Server
                                 if (msgIn.MessageType == "2")
                                 {
                                     // Request from chargepoint to OCPP server
-                                    OCPPMessage msgOut = controller16.ProcessRequest(msgIn);
+                                    OCPPMessage msgOut = await controller16.ProcessRequest(msgIn);
 
                                     // Send OCPP message with optional logging/dump
                                     await SendOcpp16Message(msgOut, logger, chargePointStatus.WebSocket);

--- a/OCPP.Core.Server/OCPPMiddleware.OCPP20.cs
+++ b/OCPP.Core.Server/OCPPMiddleware.OCPP20.cs
@@ -79,7 +79,7 @@ namespace OCPP.Core.Server
                                 if (msgIn.MessageType == "2")
                                 {
                                     // Request from chargepoint to OCPP server
-                                    OCPPMessage msgOut = controller20.ProcessRequest(msgIn);
+                                    OCPPMessage msgOut = await controller20.ProcessRequest(msgIn);
 
                                     // Send OCPP message with optional logging/dump
                                     await SendOcpp20Message(msgOut, logger, chargePointStatus.WebSocket);


### PR DESCRIPTION
1) Writing to the MessageLog table causes an insert which for me takes on average about 16ms. However this is usually not something we need to wait for. We would save this 16ms several times when starting a session if we just launch a task to do it and disregard the answer. `_ = WriteMessageLog` means we will fire and forget the task..

If we get an exception in this task it gets logged anyway, nothing changes there.

2) Some optimisation where you just need to check if a transaction exists, not actually need to fetch it.

3) Chose not to add await ... async for all the database calls, becaues this only speeds it up when you have a significant server load. For this project it would indeed be usefull to do it but chose not to do it in this pull request. However now that more function are async it's easier to do it in a later pull request.

**Note I did not test any of this yet. Just make sure it compiles. Will test in the coming weeks.**

