### PR TITLE
Export refactor and add xlsx

### DIFF
--- a/OCPP.Core.Database/ConnectorStatus.cs
+++ b/OCPP.Core.Database/ConnectorStatus.cs
@@ -18,7 +18,6 @@
  */
 
 using System;
-using System.Collections.Generic;
 
 #nullable disable
 
@@ -28,13 +27,23 @@ namespace OCPP.Core.Database
     {
         public string ChargePointId { get; set; }
         public int ConnectorId { get; set; }
-
         public string ConnectorName { get; set; }
-
         public string LastStatus { get; set; }
         public DateTime? LastStatusTime { get; set; }
-
         public double? LastMeter { get; set; }
         public DateTime? LastMeterTime { get; set; }
+        public virtual ChargePoint ChargePoint { get; set; }
+
+        public override string ToString()
+        {
+            string chargePointName = ChargePoint?.Name ?? ChargePointId;
+            if (!string.IsNullOrEmpty(ConnectorName))
+            {
+                return ConnectorName;
+            }
+
+            return $"{chargePointName}:{ConnectorId}";
+        }
     }
 }
+

--- a/OCPP.Core.Management/Controllers/HomeController.Export.cs
+++ b/OCPP.Core.Management/Controllers/HomeController.Export.cs
@@ -1,183 +1,148 @@
-﻿/*
- * OCPP.Core - https://github.com/dallmann-consulting/OCPP.Core
- * Copyright (C) 2020-2021 dallmann consulting GmbH.
- * All Rights Reserved.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- */
-
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using OCPP.Core.Database;
 using OCPP.Core.Management.Models;
+using ClosedXML.Excel;
+using Microsoft.EntityFrameworkCore;
 
 namespace OCPP.Core.Management.Controllers
 {
     public partial class HomeController : BaseController
     {
-        const char CSV_Seperator = ';';
+        private const char DefaultCSVSeparator = ';';
 
         [Authorize]
-        public IActionResult Export(string Id, string ConnectorId)
+        public IActionResult ExportCsv(string Id, string ConnectorId)
         {
-            Logger.LogTrace("Export: Loading charge point transactions...");
-
-            int currentConnectorId = -1;
-            int.TryParse(ConnectorId, out currentConnectorId);
-
-            TransactionListViewModel tlvm = new TransactionListViewModel();
-            tlvm.CurrentChargePointId = Id;
-            tlvm.CurrentConnectorId = currentConnectorId;
-            tlvm.ConnectorStatuses = new List<ConnectorStatus>();
-            tlvm.Transactions = new List<Transaction>();
-
             try
             {
-                string ts = Request.Query["t"];
-                int days = 30;
-                if (ts == "2")
-                {
-                    // 90 days
-                    days = 90;
-                    tlvm.Timespan = 2;
-                }
-                else if (ts == "3")
-                {
-                    // 365 days
-                    days = 365;
-                    tlvm.Timespan = 3;
-                }
-                else
-                {
-                    // 30 days
-                    days = 30;
-                    tlvm.Timespan = 1;
-                }
+                var tlvm = LoadTransactionListViewModel(Id, ConnectorId);
+                var workbook = CreateSpreadsheet(tlvm);
 
-                string currentConnectorName = string.Empty;
+                using var memoryStream = new MemoryStream();
+                IEnumerable<string> lines = workbook.Worksheet(1).RowsUsed().Select(row =>
+                    string.Join(DefaultCSVSeparator, row.Cells(1, row.LastCellUsed(XLCellsUsedOptions.AllContents).Address.ColumnNumber)
+                                                    .Select(cell => EscapeCsvValue(cell.GetValue<string>(), DefaultCSVSeparator))));
 
-                Logger.LogTrace("Export: Loading charge points...");
-                tlvm.ConnectorStatuses = DbContext.ConnectorStatuses.ToList<ConnectorStatus>();
-
-                // Preferred: use specific connector name
-                foreach (ConnectorStatus cs in tlvm.ConnectorStatuses)
+                using (var writer = new StreamWriter(memoryStream, Encoding.GetEncoding("ISO-8859-1"), 1024, true))
                 {
-                    if (cs.ChargePointId == Id && cs.ConnectorId == currentConnectorId)
+                    foreach (var line in lines)
                     {
-                        currentConnectorName = cs.ConnectorName;
-                        /*
-                        if (string.IsNullOrEmpty(tlvm.CurrentConnectorName))
-                        {
-                            currentConnectorName = $"{Id}:{cs.ConnectorId}";
-                        }
-                        */
-                        break;
-                    }
-                }
-                // default: combined name with charge point and connector
-                if (string.IsNullOrEmpty(currentConnectorName))
-                {
-                    tlvm.ChargePoints = DbContext.ChargePoints.ToList<ChargePoint>();
-                    foreach(ChargePoint cp in tlvm.ChargePoints)
-                    {
-                        if (cp.ChargePointId == Id)
-                        {
-                            currentConnectorName = $"{cp.Name}:{currentConnectorId}";
-                            break;
-                        }
-                    }
-                    if (string.IsNullOrEmpty(currentConnectorName))
-                    {
-                        // Fallback: ID + connector
-                        currentConnectorName = $"{Id}:{currentConnectorId}";
+                        writer.WriteLine(line);
                     }
                 }
 
-                // load charge tags for name resolution
-                Logger.LogTrace("Export: Loading charge tags...");
-                List<ChargeTag> chargeTags = DbContext.ChargeTags.ToList<ChargeTag>();
-                tlvm.ChargeTags = new Dictionary<string, ChargeTag>();
-                if (chargeTags != null)
-                {
-                    foreach (ChargeTag tag in chargeTags)
-                    {
-                        tlvm.ChargeTags.Add(tag.TagId, tag);
-                    }
-                }
-
-                if (!string.IsNullOrEmpty(tlvm.CurrentChargePointId))
-                {
-                    Logger.LogTrace("Export: Loading charge point transactions...");
-                    tlvm.Transactions = DbContext.Transactions
-                                        .Where(t => t.ChargePointId == tlvm.CurrentChargePointId &&
-                                                    t.ConnectorId == tlvm.CurrentConnectorId &&
-                                                    t.StartTime >= DateTime.UtcNow.AddDays(-1 * days))
-                                        .OrderByDescending(t => t.TransactionId)
-                                        .ToList<Transaction>();
-                }
-
-                StringBuilder connectorName = new StringBuilder(currentConnectorName);
-                foreach (char c in Path.GetInvalidFileNameChars())
-                {
-                    connectorName.Replace(c, '_');
-                }
-
-                string filename = string.Format("Transactions_{0}.csv", connectorName);
-                string csv = CreateCsv(tlvm, currentConnectorName);
-                Logger.LogInformation("Export: File => {0} Chars / Name '{1}'", csv.Length, filename);
-
-                return File(Encoding.GetEncoding("ISO-8859-1").GetBytes(csv), "text/csv", filename);
+                memoryStream.Position = 0;
+                return File(memoryStream.ToArray(), "text/csv", $"Transactions_{SanitizeFileName(tlvm.CurrentConnectorName)}.csv");
             }
             catch (Exception exp)
             {
-                Logger.LogError(exp, "Export: Error loading data from database");
+                Logger.LogError(exp, "Export CSV: Error loading data from database");
+                return StatusCode(500, "Internal server error");
             }
-
-            return View(tlvm);
         }
 
-        private string CreateCsv(TransactionListViewModel tlvm, string currentConnectorName)
+        [Authorize]
+        public IActionResult ExportXlsx(string Id, string ConnectorId)
         {
-            StringBuilder csv = new StringBuilder(8192);
-            csv.Append(EscapeCsvValue(_localizer["Connector"]));
-            csv.Append(CSV_Seperator);
-            csv.Append(EscapeCsvValue(_localizer["StartTime"]));
-            csv.Append(CSV_Seperator);
-            csv.Append(EscapeCsvValue(_localizer["StartTag"]));
-            csv.Append(CSV_Seperator);
-            csv.Append(EscapeCsvValue(_localizer["StartMeter"]));
-            csv.Append(CSV_Seperator);
-            csv.Append(EscapeCsvValue(_localizer["StopTime"]));
-            csv.Append(CSV_Seperator);
-            csv.Append(EscapeCsvValue(_localizer["StopTag"]));
-            csv.Append(CSV_Seperator);
-            csv.Append(EscapeCsvValue(_localizer["StopMeter"]));
-            csv.Append(CSV_Seperator);
-            csv.Append(EscapeCsvValue(_localizer["ChargeSum"]));
-
-            if (tlvm != null && tlvm.Transactions != null)
+            try
             {
-                foreach (Transaction t in tlvm.Transactions)
+                var tlvm = LoadTransactionListViewModel(Id, ConnectorId);
+                var workbook = CreateSpreadsheet(tlvm);
+
+                using var memoryStream = new MemoryStream();
+                workbook.SaveAs(memoryStream);
+                memoryStream.Position = 0;
+
+                return File(memoryStream.ToArray(), "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", $"Transactions_{SanitizeFileName(tlvm.CurrentConnectorName)}.xlsx");
+            }
+            catch (Exception exp)
+            {
+                Logger.LogError(exp, "Export XLSX: Error loading data from database");
+                return StatusCode(500, "Internal server error");
+            }
+        }
+
+        private TransactionListViewModel LoadTransactionListViewModel(string Id, string ConnectorId)
+        {
+            Logger.LogTrace("Export: Loading charge point transactions...");
+
+            if (!int.TryParse(ConnectorId, out int currentConnectorId))
+            {
+                currentConnectorId = -1;
+            }
+
+            var tlvm = new TransactionListViewModel
+            {
+                CurrentChargePointId = Id,
+                CurrentConnectorId = currentConnectorId,
+                ConnectorStatuses = new List<ConnectorStatus>(),
+                Transactions = new List<Transaction>()
+            };
+
+            string ts = Request.Query["t"];
+            int days = ts switch
+            {
+                "2" => 90,
+                "3" => 365,
+                _ => 30,
+            };
+            tlvm.Timespan = ts switch
+            {
+                "2" => 2,
+                "3" => 3,
+                _ => 1,
+            };
+
+            Logger.LogTrace("Export: Loading charge points...");
+            tlvm.ConnectorStatuses = DbContext.ConnectorStatuses.Include(cs => cs.ChargePoint).ToList();
+
+            tlvm.CurrentConnectorName = tlvm.ConnectorStatuses
+                .FirstOrDefault(cs => cs.ChargePointId == Id && cs.ConnectorId == currentConnectorId)?.ToString() ?? $"{Id}:{currentConnectorId}";
+
+            Logger.LogTrace("Export: Loading charge tags...");
+            var chargeTags = DbContext.ChargeTags.ToList();
+            tlvm.ChargeTags = chargeTags.ToDictionary(tag => tag.TagId);
+
+            if (!string.IsNullOrEmpty(tlvm.CurrentChargePointId))
+            {
+                Logger.LogTrace("Export: Loading charge point transactions...");
+                tlvm.Transactions = DbContext.Transactions
+                    .Where(t => t.ChargePointId == tlvm.CurrentChargePointId &&
+                                t.ConnectorId == tlvm.CurrentConnectorId &&
+                                t.StartTime >= DateTime.UtcNow.AddDays(-1 * days))
+                    .OrderByDescending(t => t.TransactionId)
+                    .AsNoTracking()
+                    .ToList();
+            }
+
+            return tlvm;
+        }
+
+        private XLWorkbook CreateSpreadsheet(TransactionListViewModel tlvm)
+        {
+            var workbook = new XLWorkbook();
+            var worksheet = workbook.Worksheets.Add("Transactions");
+
+            worksheet.Cell(1, 1).Value = _localizer["Connector"].ToString();
+            worksheet.Cell(1, 2).Value = _localizer["StartTime"].ToString();
+            worksheet.Cell(1, 3).Value = _localizer["StartTag"].ToString();
+            worksheet.Cell(1, 4).Value = _localizer["StartMeter"].ToString();
+            worksheet.Cell(1, 5).Value = _localizer["StopTime"].ToString();
+            worksheet.Cell(1, 6).Value = _localizer["StopTag"].ToString();
+            worksheet.Cell(1, 7).Value = _localizer["StopMeter"].ToString();
+            worksheet.Cell(1, 8).Value = _localizer["ChargeSum"].ToString();
+
+            if (tlvm?.Transactions != null)
+            {
+                int row = 2;
+                foreach (var t in tlvm.Transactions)
                 {
                     string startTag = t.StartTagId;
                     string stopTag = t.StopTagId;
@@ -190,45 +155,42 @@ namespace OCPP.Core.Management.Controllers
                         stopTag = tlvm.ChargeTags[t.StopTagId]?.TagName;
                     }
 
-                    csv.AppendLine();
-                    csv.Append(EscapeCsvValue(currentConnectorName));
-                    csv.Append(CSV_Seperator);
-                    csv.Append(EscapeCsvValue(t.StartTime.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss")));
-                    csv.Append(CSV_Seperator);
-                    csv.Append(EscapeCsvValue(startTag));
-                    csv.Append(CSV_Seperator);
-                    csv.Append(EscapeCsvValue(string.Format("{0:0.0##}", t.MeterStart)));
-                    csv.Append(CSV_Seperator);
-                    csv.Append(EscapeCsvValue(((t.StopTime != null) ? t.StopTime.Value.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss") : string.Empty)));
-                    csv.Append(CSV_Seperator);
-                    csv.Append(EscapeCsvValue(stopTag));
-                    csv.Append(CSV_Seperator);
-                    csv.Append(EscapeCsvValue(((t.MeterStop != null) ? string.Format("{0:0.0##}", t.MeterStop) : string.Empty)));
-                    csv.Append(CSV_Seperator);
-                    csv.Append(EscapeCsvValue(((t.MeterStop != null) ? string.Format("{0:0.0##}", (t.MeterStop - t.MeterStart)) : string.Empty)));
+                    worksheet.Cell(row, 1).Value = tlvm.CurrentConnectorName;
+                    worksheet.Cell(row, 2).Value = t.StartTime.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss");
+                    worksheet.Cell(row, 3).Value = startTag;
+                    worksheet.Cell(row, 4).Value = $"{t.MeterStart:0.0##}";
+                    worksheet.Cell(row, 5).Value = t.StopTime?.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss") ?? string.Empty;
+                    worksheet.Cell(row, 6).Value = stopTag;
+                    worksheet.Cell(row, 7).Value = t.MeterStop.HasValue ? $"{t.MeterStop:0.0##}" : string.Empty;
+                    worksheet.Cell(row, 8).Value = t.MeterStop.HasValue ? $"{t.MeterStop - t.MeterStart:0.0##}" : string.Empty;
+
+                    row++;
                 }
             }
 
-            return csv.ToString();
+            worksheet.Columns().AdjustToContents();
+
+            return workbook;
         }
 
-        private string EscapeCsvValue(string value)
+        private string EscapeCsvValue(string value, char separator)
         {
-            if (!string.IsNullOrEmpty(value))
+            if (!string.IsNullOrEmpty(value) && (value.Contains(separator) || value.Contains('"')))
             {
-                if (value.Contains(CSV_Seperator))
-                {
-                    if (value.Contains('"'))
-                    {
-                        // replace '"' with '""'
-                        value.Replace("\"", "\"\"");
-                    }
-
-                    // put value in "
-                    value = string.Format("\"{0}\"", value);
-                }
+                value = $"\"{value.Replace("\"", "\"\"")}\"";
             }
             return value;
+        }
+
+        private string SanitizeFileName(string fileName)
+        {
+            var invalidChars = Path.GetInvalidFileNameChars();
+            var sanitizedFileName = new StringBuilder(fileName);
+            foreach (var c in invalidChars)
+            {
+                sanitizedFileName.Replace(c, '_');
+            }
+            return sanitizedFileName.ToString();
         }
     }
 }

--- a/OCPP.Core.Management/Controllers/HomeController.Export.cs
+++ b/OCPP.Core.Management/Controllers/HomeController.Export.cs
@@ -18,7 +18,7 @@ namespace OCPP.Core.Management.Controllers
         private const char DefaultCSVSeparator = ';';
 
         [Authorize]
-        public IActionResult ExportCsv(string Id, string ConnectorId)
+        public IActionResult Export(string Id, string ConnectorId)
         {
             try
             {

--- a/OCPP.Core.Management/Models/TransactionListViewModel.cs
+++ b/OCPP.Core.Management/Models/TransactionListViewModel.cs
@@ -37,7 +37,7 @@ namespace OCPP.Core.Management.Models
 
         public int CurrentConnectorId { get; set; }
 
-        //public string CurrentConnectorName { get; set; }
+        public string CurrentConnectorName { get; set; }
 
         public List<Transaction> Transactions { get; set; }
 

--- a/OCPP.Core.Management/OCPP.Core.Management.csproj
+++ b/OCPP.Core.Management/OCPP.Core.Management.csproj
@@ -27,6 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="ClosedXML" Version="0.102.2" />
     <PackageReference Include="Karambolo.Extensions.Logging.File" Version="3.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>

--- a/OCPP.Core.Management/Views/Home/Transactions.cshtml
+++ b/OCPP.Core.Management/Views/Home/Transactions.cshtml
@@ -111,7 +111,7 @@
         <div class="col-3">
         </div>
         <div class="col-md-auto align-self-center">
-            <a href="~/Home/ExportCsv/@Uri.EscapeDataString(Model.CurrentChargePointId)/@Model.CurrentConnectorId@timespan" data-toggle="tooltip" data-placement="top" title="@Localizer["DownloadCsv"]">
+            <a href="~/Home/Export/@Uri.EscapeDataString(Model.CurrentChargePointId)/@Model.CurrentConnectorId@timespan" data-toggle="tooltip" data-placement="top" title="@Localizer["DownloadCsv"]">
                 <i class="fas fa-file-csv fa-2x"></i>
             </a>
             <a href="~/Home/ExportXlsx/@Uri.EscapeDataString(Model.CurrentChargePointId)/@Model.CurrentConnectorId@timespan" data-toggle="tooltip" data-placement="top" title="@Localizer["DownloadXlsx"]">

--- a/OCPP.Core.Management/Views/Home/Transactions.cshtml
+++ b/OCPP.Core.Management/Views/Home/Transactions.cshtml
@@ -91,17 +91,14 @@
                     @if (Model.Timespan == 2)
                     {
                         @Localizer["TimeSpan90"]
-                        ;
                     }
                     else if (Model.Timespan == 3)
                     {
                         @Localizer["TimeSpan365"]
-                        ;
                     }
                     else
                     {
                         @Localizer["TimeSpan30"]
-                        ;
                     }
                 </button>
                 <div class="dropdown-menu" aria-labelledby="ddbTimespan">

--- a/OCPP.Core.Management/Views/Home/Transactions.cshtml
+++ b/OCPP.Core.Management/Views/Home/Transactions.cshtml
@@ -20,7 +20,6 @@
         }
     }
 
-
     // Count connectors for every charge point (=> naming scheme)
     Dictionary<string, int> dictConnectorCount = new Dictionary<string, int>();
     string currentConnectorName = string.Empty;
@@ -91,15 +90,18 @@
                 <button class="btn btn-secondary dropdown-toggle" type="button" id="ddbTimespan" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     @if (Model.Timespan == 2)
                     {
-                        @Localizer["TimeSpan90"];
+                        @Localizer["TimeSpan90"]
+                        ;
                     }
                     else if (Model.Timespan == 3)
                     {
-                        @Localizer["TimeSpan365"];
+                        @Localizer["TimeSpan365"]
+                        ;
                     }
                     else
                     {
-                        @Localizer["TimeSpan30"];
+                        @Localizer["TimeSpan30"]
+                        ;
                     }
                 </button>
                 <div class="dropdown-menu" aria-labelledby="ddbTimespan">
@@ -112,8 +114,11 @@
         <div class="col-3">
         </div>
         <div class="col-md-auto align-self-center">
-            <a href="~/Home/Export/@Uri.EscapeDataString(Model.CurrentChargePointId)/@Model.CurrentConnectorId@timespan" data-toggle="tooltip" data-placement="top" title="@Localizer["DownloadCsv"]">
+            <a href="~/Home/ExportCsv/@Uri.EscapeDataString(Model.CurrentChargePointId)/@Model.CurrentConnectorId@timespan" data-toggle="tooltip" data-placement="top" title="@Localizer["DownloadCsv"]">
                 <i class="fas fa-file-csv fa-2x"></i>
+            </a>
+            <a href="~/Home/ExportXlsx/@Uri.EscapeDataString(Model.CurrentChargePointId)/@Model.CurrentConnectorId@timespan" data-toggle="tooltip" data-placement="top" title="@Localizer["DownloadXlsx"]">
+                <i class="fas fa-file-excel fa-2x"></i>
             </a>
         </div>
     </div>
@@ -166,4 +171,3 @@
         </tbody>
     </table>
 }
-


### PR DESCRIPTION
Remade how the CSV is created and added XSLX aswell.

Kept the non standard ";" as separation characters because that enables a **european** Excel install to open the csv files with excel without having to modify it. But keeping csv standard to comma should be better. This is why I added xlsx export. Since now you can open that with excel the csv kan be returned to actual standard format if you want.

Noticed now I removed the license on top if the file, can replace it if you want but why do this on top of every file..