### PR TITLE
Fix ArgumentException when maintaining websocket status in dictionary

### DIFF
--- a/OCPP.Core.Server/OCPPMiddleware.cs
+++ b/OCPP.Core.Server/OCPPMiddleware.cs
@@ -194,10 +194,14 @@ namespace OCPP.Core.Server
                                         {
                                             // Closed or aborted => remove
                                             _chargePointStatusDict.Remove(chargepointIdentifier);
+                                            _chargePointStatusDict.Add(chargepointIdentifier, chargePointStatus);
                                         }
                                     }
+                                    else
+                                    {
+                                        _chargePointStatusDict.Add(chargepointIdentifier, chargePointStatus);
+                                    }
 
-                                    _chargePointStatusDict.Add(chargepointIdentifier, chargePointStatus);
                                     statusSuccess = true;
                                 }
                             }


### PR DESCRIPTION
The current code causes a [ArgumentException](https://learn.microsoft.com/en-us/dotnet/api/system.argumentexception?view=net-8.0) as when the key already exists and the socket connection is open the current code will always try to add a new entry to the dictionary

