### PR TITLE
`TransasctionEvent` req w/o `meterValues` fails to be `FormationViolation`

### DIFF
--- a/OCPP.Core.Server/ControllerOCPP20.TransactionEvent.cs
+++ b/OCPP.Core.Server/ControllerOCPP20.TransactionEvent.cs
@@ -129,7 +129,7 @@ namespace OCPP.Core.Server
                                 transaction.Uid = transactionEventRequest.TransactionInfo.TransactionId;
                                 transaction.ChargePointId = ChargePointStatus?.Id;
                                 transaction.ConnectorId = connectorId;
-                                transaction.StartTagId = ct.TagId;
+                                transaction.StartTagId = ct?.TagId;
                                 transaction.StartTime = transactionEventRequest.Timestamp.UtcDateTime;
                                 transaction.MeterStart = meterKWH;
                                 transaction.StartResult = transactionEventRequest.TriggerReason.ToString();
@@ -328,7 +328,7 @@ namespace OCPP.Core.Server
             meterTime = null;
             stateOfCharge = -1;
 
-            foreach (MeterValueType meterValue in meterValues)
+            foreach (MeterValueType meterValue in meterValues ?? [])
             {
                 foreach (SampledValueType sampleValue in meterValue.SampledValue)
                 {


### PR DESCRIPTION
`TransactionEvent` request with no `meterValues` property fails to be replied `FormationViolation`.

```javascript
// Request to OCPP.Core
// Has no `meterValues` prop.
[
    2,
    "OCPP_MSG_3735759508",
    "TransactionEvent",
    {
        "eventType": "Started",
        "timestamp": "2022-12-31T23:00:06",
        "triggerReason": "CablePluggedIn",
        "seqNo": 6270,
        "transactionInfo": {
            "transactionId": "test-id"
        }
    }
]

// Response from OCPP.Core
[
    4,
    "OCPP_MSG_3735759508",
    "FormationViolation",
    "",
    {}
]
```

```text
// `OCPP.Core.Server.dll` Log

info: OCPPMiddleware.OCPP20[0]
      OCPPMiddleware.Receive20 => OCPP-Message: Type=2 / ID=OCPP_MSG_3735759508 / Action=TransactionEvent)

fail: OCPP.Core.Server.ControllerOCPP20[0]
      TransactionEvent => Exception: Object reference not set to an instance of an object.
      System.NullReferenceException: Object reference not set to an instance of an object.
         at OCPP.Core.Server.ControllerOCPP20.GetMeterValues(ICollection`1 meterValues, Double& meterKWH, Double& currentChargeKW, Double& stateOfCharge, Nullable`1& meterTime) in /xxxxxx/OCPP.Core/OCPP.Core.Server/ControllerOCPP20.TransactionEvent.cs:line 331
         at OCPP.Core.Server.ControllerOCPP20.HandleTransactionEvent(OCPPMessage msgIn, OCPPMessage msgOut) in /xxxxxx/OCPP.Core/OCPP.Core.Server/ControllerOCPP20.TransactionEvent.cs:line 60
```

----

`meterValues` prop of `TransactionEvent` req is optional, however, without it,
it fails in `GetMeterValues()` in `foreach` for `meterValues` of null-reference.

Besides, ahead of there, it can fail if ChargeTag `ct` is `null`, too.

At least, these two parts should be `null`-value considered.
