### PR TITLE
Added key "Celsius" to enum SampledValueUnit.

### DIFF
--- a/OCPP.Core.Server/Messages_OCPP16/StopTransactionRequest.cs
+++ b/OCPP.Core.Server/Messages_OCPP16/StopTransactionRequest.cs
@@ -350,6 +350,9 @@ namespace OCPP.Core.Server.Messages_OCPP16
         [System.Runtime.Serialization.EnumMember(Value = @"Celcius")]
         Celcius = 13,
 
+        [System.Runtime.Serialization.EnumMember(Value = @"Celsius")]
+        Celsius = 16,
+
         [System.Runtime.Serialization.EnumMember(Value = @"Fahrenheit")]
         Fahrenheit = 14,
 


### PR DESCRIPTION
Previously, if a ChargePoint sent a SampledValue with Unit set to "Celsius" (instead of "Celcius"), it would fail to be parsed since said key was not included in the enum SampledValueUnit.