### PR TITLE
:lock: bump some packages to remove vulnerable deps

### DIFF
--- a/Extensions/OCPP.Core.Extensions.AzureServiceBus/OCPP.Core.Extensions.AzureServiceBus.csproj
+++ b/Extensions/OCPP.Core.Extensions.AzureServiceBus/OCPP.Core.Extensions.AzureServiceBus.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/OCPP.Core.Database/OCPP.Core.Database.csproj
+++ b/OCPP.Core.Database/OCPP.Core.Database.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.8">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.14" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.14" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.14" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.14">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/OCPP.Core.Management/OCPP.Core.Management.csproj
+++ b/OCPP.Core.Management/OCPP.Core.Management.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClosedXML" Version="0.102.3" />
+    <PackageReference Include="ClosedXML" Version="0.104.2" />
     <PackageReference Include="Karambolo.Extensions.Logging.File" Version="3.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>


### PR DESCRIPTION
Some transitive packages for project dependencies are listed as vulnerabilities in different levels. Update remove the warnings bumpt patch or minor versions only (the first one which uses updated transitive dependency):

1. `System.Text.Json` 8.0.0:
    - Vulnerability: [GHSA-8g4q-xg66-9fp4](https://github.com/advisories/GHSA-8g4q-xg66-9fp4)
    - Vulnerability: [GHSA-hh2w-p6rv-4g7w](https://github.com/advisories/GHSA-hh2w-p6rv-4g7w)

2. `System.Text.Json` 8.0.4:
    - Vulnerability: [GHSA-8g4q-xg66-9fp4](https://github.com/advisories/GHSA-8g4q-xg66-9fp4)

3. `Microsoft.Extensions.Caching.Memory` 8.0.0:
    - Vulnerability: [GHSA-qj66-m88j-hmgj](https://github.com/advisories/GHSA-qj66-m88j-hmgj)

4. `System.Formats.Asn1` 5.0.0:
    - Vulnerability: [GHSA-447r-wph3-92pm](https://github.com/advisories/GHSA-447r-wph3-92pm)

5. `System.IO.Packaging` 6.0.0:
    - Vulnerability: [GHSA-f32c-w444-8ppv](https://github.com/advisories/GHSA-f32c-w444-8ppv)
    - Vulnerability: [GHSA-qj66-m88j-hmgj](https://github.com/advisories/GHSA-qj66-m88j-hmgj)

1. `Azure.Identity` 1.10.3:
    - Vulnerability: [GHSA-m5vv-6r4h-3vj9](https://github.com/advisories/GHSA-m5vv-6r4h-3vj9)
    - Vulnerability: [GHSA-wvxc-855f-jvrv](https://github.com/advisories/GHSA-wvxc-855f-jvrv)

2. `Microsoft.Identity.Client` 4.56.0:
    - Vulnerability: [GHSA-m5vv-6r4h-3vj9](https://github.com/advisories/GHSA-m5vv-6r4h-3vj9)

1. `Microsoft.Identity.Client` 4.56.0:
    - Vulnerability: [GHSA-x674-v45j-fwxw](https://github.com/advisories/GHSA-x674-v45j-fwxw)

Thanks!