### PR TITLE
Add support for GetConfiguration messages in OCPP 1.6

### DIFF
--- a/OCPP.Core.Management/Models/ChargePointViewModel.cs
+++ b/OCPP.Core.Management/Models/ChargePointViewModel.cs
@@ -50,5 +50,7 @@ namespace OCPP.Core.Management.Models
 
         [StringLength(100)]
         public string ClientCertThumb { get; set; }
+
+        public Dictionary<string, (string, bool)> DeviceConfiguration { get; set; } = new Dictionary<string, (string, bool)>();
     }
 }

--- a/OCPP.Core.Management/Resources/Views.Home.ChargePointDetail.de.resx
+++ b/OCPP.Core.Management/Resources/Views.Home.ChargePointDetail.de.resx
@@ -186,6 +186,9 @@
   <data name="Title" xml:space="preserve">
     <value>Management</value>
   </data>
+  <data name="TitleDeviceConfiguration" xml:space="preserve">
+    <value>Aktuelle Gerätekonfiguration</value>
+  </data>
   <data name="TitleReset" xml:space="preserve">
     <value>Neustart</value>
   </data>

--- a/OCPP.Core.Management/Resources/Views.Home.ChargePointDetail.resx
+++ b/OCPP.Core.Management/Resources/Views.Home.ChargePointDetail.resx
@@ -186,6 +186,9 @@
   <data name="Title" xml:space="preserve">
     <value>Management</value>
   </data>
+  <data name="TitleDeviceConfiguration" xml:space="preserve">
+    <value>Current Device Configuration</value>
+  </data>
   <data name="TitleReset" xml:space="preserve">
     <value>Restart</value>
   </data>

--- a/OCPP.Core.Management/Views/Home/ChargePointDetail.cshtml
+++ b/OCPP.Core.Management/Views/Home/ChargePointDetail.cshtml
@@ -157,7 +157,28 @@
             }
         </div>
     }
+    <br />
 
+    @if(Model.DeviceConfiguration?.Count > 0)
+    {
+        <h4>@Localizer["TitleDeviceConfiguration"]</h4>
+        <br />
+        <div class="container">
+            <div class="row">
+                <div class="col-sm-5"><b>Key</b></div>
+                <div class="col-sm-6"><b>Value</b></div>
+                <div class="col-sm-1"><b>Writable</b></div>
+            </div>
+            @foreach(var config in Model.DeviceConfiguration)
+            {
+                <div class="row border-top">
+                    <div class="col-sm-5">@config.Key</div>
+                    <div class="col-sm-6">@config.Value.Item1</div>
+                    <div class="col-sm-1"><i class="fas fa-@(config.Value.Item2 ? "times" : "check")"></i></div>
+                </div>
+            }
+        </div>
+    }
 
     @section scripts {
         @if (!string.IsNullOrWhiteSpace(Model.ChargePointId))

--- a/OCPP.Core.Server/ControllerOCPP16.GetConfiguration.cs
+++ b/OCPP.Core.Server/ControllerOCPP16.GetConfiguration.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.Extensions.Logging;
+using OCPP.Core.Server.Messages_OCPP16;
+using System;
+
+namespace OCPP.Core.Server
+{
+	public partial class ControllerOCPP16
+	{
+		public void HandleGetConfiguration(OCPPMessage msgIn, OCPPMessage msgOut)
+		{
+			Logger.LogInformation("GetConfiguration answer: ChargePointId={0} / MsgType={1} / ErrCode={2}", ChargePointStatus.Id, msgIn.MessageType, msgIn.ErrorCode);
+
+			try
+			{
+				var getConfigurationResponse = DeserializeMessage<GetConfigurationResponse>(msgIn);
+				Logger.LogInformation("GetConfiguration => KeyCount: {0}", getConfigurationResponse.ConfigurationKey?.Count);
+				WriteMessageLog(ChargePointStatus?.Id, null, msgOut.Action, getConfigurationResponse.ConfigurationKey?.ToString(), msgIn.ErrorCode);
+
+				if(msgOut.TaskCompletionSource != null)
+				{
+					msgOut.TaskCompletionSource.SetResult(msgIn.JsonPayload);
+				}
+			}
+			catch(Exception exp)
+			{
+				Logger.LogError(exp, "GetConfiguration => Exception: {0}", exp.Message);
+			}
+		}
+	}
+}

--- a/OCPP.Core.Server/ControllerOCPP16.cs
+++ b/OCPP.Core.Server/ControllerOCPP16.cs
@@ -136,6 +136,10 @@ namespace OCPP.Core.Server
                     HandleClearChargingProfile(msgIn, msgOut);
                     break;
 
+                case "GetConfiguration":
+                    HandleGetConfiguration(msgIn, msgOut);
+                    break;
+
                 default:
                     WriteMessageLog(ChargePointStatus.Id, null, msgIn.Action, msgIn.JsonPayload, "Unknown answer");
                     break;

--- a/OCPP.Core.Server/Messages_OCPP16/GetConfigurationRequest.cs
+++ b/OCPP.Core.Server/Messages_OCPP16/GetConfigurationRequest.cs
@@ -1,0 +1,11 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace OCPP.Core.Server.Messages_OCPP16
+{
+	public class GetConfigurationRequest
+	{
+		[JsonProperty("key")]
+		public ICollection<string> Key {  get; set; }
+	}
+}

--- a/OCPP.Core.Server/Messages_OCPP16/GetConfigurationResponse.cs
+++ b/OCPP.Core.Server/Messages_OCPP16/GetConfigurationResponse.cs
@@ -1,0 +1,20 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace OCPP.Core.Server.Messages_OCPP16
+{
+	public class GetConfigurationResponse
+	{
+		[JsonProperty("configurationKey")]
+		public ICollection<OcppKeyValue> ConfigurationKey { get; set; }
+		[JsonProperty("unknownKey")]
+		public ICollection<string> UnknownKey { get; set; }
+	}
+
+	public class OcppKeyValue
+	{
+		public string Key { get; set; }
+		public bool ReadOnly { get; set; }
+		public string Value { get; set; }
+	}
+}


### PR DESCRIPTION
Added support for GetConfiguration messages.  Unfortunately I only have a 1.6 charge point, so I've only added message support for this, but it shouldn't break where charge points are 2.0; instead the information won't be displayed.  Obviously open for anyone else to add the relevant handlers in.

These messages bring back all the key/value pairs from the charge point which define the operation, which can be useful to know when troubleshooting.  When navigating into a charge point through the admin user interface, it will send a GetConfiguration message to the charge point, which assuming the charge point responds, will be displayed.

This isn't entirely feature complete as there is paging support in OCPP to handle a limited number of values being returned in small batches.  I'm not sure how much that's actually used in the real world (my charge point claims only to allow single values to be retrieved, but it then returns all of them).

The obvious next step would be to make the values display on an input form and allow the submission of new values.

I've tried to emulate the procedural coding style and approaches already taken for consistency.